### PR TITLE
add coalesce option to make full frames

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -2,7 +2,7 @@ require 'pry'
 
 Dir.glob('./before_convert/*').each do |before|
   target_gif = before
-  system "convert -strip #{target_gif} ./tmp/working.png"
+  system "convert -coalesce -strip #{target_gif} ./tmp/working.png"
 
   Dir.glob('./tmp/*.png').each do |fname|
     cnt = fname.split('working-')[1].split('.png')[0]


### PR DESCRIPTION
おそらく差分圧縮されたgif画像の場合には差分のみのサイズが異なるpngが生成され、出力されたgifで重ねたlgtmの文字がずれるので、coalesceオプションを付与しました。

表示が崩れる素材例：https://45.media.tumblr.com/97a9e04a191d0bd15277f6f3f755a4c9/tumblr_o63bpnwSNJ1qd227ho1_400.gif

参考：http://www.imagemagick.org/script/command-line-options.php#coalesce
